### PR TITLE
Change the order of writing the settings file during Expand-CrmData

### DIFF
--- a/src/CrmDataPackager/CrmDataPackager.psd1
+++ b/src/CrmDataPackager/CrmDataPackager.psd1
@@ -4,7 +4,7 @@
 RootModule = 'CrmDataPackager.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.1'
 
 # ID used to uniquely identify this module
 GUID = 'e580eeda-2a15-41f3-8e7a-5311653662c3'
@@ -55,7 +55,7 @@ PrivateData = @{
         ProjectUri = 'https://github.com/amervitz/CrmDataPackager'
 
         # Release notes of this module
-        ReleaseNotes = 'Initial release.'
+        ReleaseNotes = 'Fix for error `Unable to find type [Newtonsoft.Json.Linq.JToken]` when running Expand-CrmData.'
     } # End of PSData hashtable
 
 } # End of PrivateData hashtable

--- a/src/CrmDataPackager/CrmDataPackager.psm1
+++ b/src/CrmDataPackager/CrmDataPackager.psm1
@@ -192,7 +192,9 @@ function CreateManifest {
 
     $formatted = [Newtonsoft.Json.Linq.JToken]::Parse($json).ToString()
 
-    Set-Content -Value $formatted -Path (Join-Path -Path $Path -ChildPath settings.json) -Encoding UTF8
+    $settingsPath = Join-Path -Path $Path -ChildPath settings.json
+    Write-Verbose "Writing file $settingsPath"
+    Set-Content -Value $formatted -Path $settingsPath -Encoding UTF8
 }
 
 function WriteFileAndUpdateRecord {
@@ -610,9 +612,9 @@ function CrmConfigurationPackager {
         Write-Verbose "Loading file $SettingsFile"
         $settings = ConvertFrom-Json (Get-Content -Raw -Path $SettingsFile)
 
-        CreateManifest -Path $DestinationPath -Settings $settings
         ExtractData -Path $dataPath -DestinationPath $DestinationPath -Settings $settings
         ExtractSchema -Path $schemaPath -DestinationPath $DestinationPath
+        CreateManifest -Path $DestinationPath -Settings $settings
     } elseif($Pack)  {
 
         # when target is a zip file, pack the contents to a temporary folder, then delete the temporary folder when done


### PR DESCRIPTION
Fixes error `Unable to find type [Newtonsoft.Json.Linq.JToken]`